### PR TITLE
Udpate algolia client to 3.7.8

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'acemtp:algolia',
   summary: 'Package to handle the blazing fast Algolia search engine (works on client and server)',
-  version: '3.4.0',
+  version: '3.7.8',
   git: 'https://github.com/acemtp/meteor-algolia.git'
 });
 
@@ -15,5 +15,5 @@ Package.onUse(function(api) {
 });
 
 Npm.depends({
-  'algoliasearch': '3.4.0'
+  'algoliasearch': '3.7.8'
 });


### PR DESCRIPTION
3.7.8 fixes issues related to using Algolia with Twitter typeahead (amongst other things)
